### PR TITLE
Set Yawar's hobbies; remove publications stats bar

### DIFF
--- a/css/redesign.css
+++ b/css/redesign.css
@@ -611,26 +611,6 @@ body.page-body {
   padding: 14px;
 }
 
-.pub-stats-bar {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  margin-top: 8px;
-  font-family: var(--sans);
-  font-size: 14px;
-  color: var(--muted);
-}
-
-.pub-stat__value {
-  font-weight: 700;
-  color: var(--muse-navy);
-}
-
-.pub-stat-sep {
-  color: var(--line-strong);
-  margin: 0 4px;
-}
-
 .pub-card__tags {
   display: flex;
   flex-wrap: wrap;

--- a/members.html
+++ b/members.html
@@ -103,7 +103,7 @@
                    <div class="card-body">
                        <h5 class="card-title">Yawar Ashraf</h5>
                        <h6 class="card-subtitle mb-2 text-muted"><strong>MASc</strong> Student</h6>
-                       <p class="card-text">Hobbies: <i>TBD</i></p>
+                       <p class="card-text">Hobbies: <i>Squash, Reading</i></p>
                    </div>
                </div>
            </div>

--- a/publication.html
+++ b/publication.html
@@ -49,13 +49,6 @@
     <div class="container mt-4">
         <div class="publication-hero content-card">
             <h1 class="page-title mb-3">Publications</h1>
-            <div class="pub-stats-bar">
-                <span class="pub-stat"><span class="pub-stat__value" data-count="499">0</span> citations</span>
-                <span class="pub-stat-sep">&middot;</span>
-                <span class="pub-stat"><span class="pub-stat__value" data-count="15">0</span> h-index</span>
-                <span class="pub-stat-sep">&middot;</span>
-                <span class="pub-stat"><span class="pub-stat__value" id="pub-count" data-count="0">0</span> publications</span>
-            </div>
         </div>
 
         <div class="pub-topics">
@@ -250,30 +243,10 @@
             });
         }
 
-        function animateCounters() {
-            document.querySelectorAll('.pub-stat__value').forEach(function(el) {
-                var target = parseInt(el.getAttribute('data-count'), 10);
-                var duration = 1200;
-                var start = null;
-                function step(ts) {
-                    if (!start) start = ts;
-                    var progress = Math.min((ts - start) / duration, 1);
-                    var ease = 1 - Math.pow(1 - progress, 3);
-                    el.textContent = Math.floor(target * ease);
-                    if (progress < 1) requestAnimationFrame(step);
-                    else el.textContent = target;
-                }
-                requestAnimationFrame(step);
-            });
-        }
-
         fetch('data/publications.json')
             .then(function(res) { return res.json(); })
             .then(function(papers) {
                 papers.sort(function(a, b) { return b.year - a.year; });
-
-                var pubCountEl = document.getElementById('pub-count');
-                if (pubCountEl) pubCountEl.setAttribute('data-count', papers.length);
 
                 var container = document.getElementById('pub-list');
                 var html = '';
@@ -331,8 +304,6 @@
                         filterCards();
                     });
                 });
-
-                animateCounters();
             });
     })();
     </script>

--- a/scripts/update_site.py
+++ b/scripts/update_site.py
@@ -417,7 +417,7 @@ def export_existing_members():
         "Amr Mohamed":      {"status": "Graduate",      "role": "MASc (Fall 2024 - Pres)",    "email": "amr.m@queensu.ca", "hobbies": "Chess, Piano, Guitar",                "photo": "amrmohamed.jpg"},
         "Michael Zhang":    {"status": "Graduate",      "role": "MEng (Mar 2024 - Pres)",     "email": "18jz111@queensu.ca","hobbies": "Skiing, camping, hiking, card and board games", "photo": "michaelzhang.jpeg"},
         "Aaliyah Chang":    {"status": "Graduate",      "role": "MASc Student in Electrical and Computer Engineering", "email": "TBD", "hobbies": "TBD", "photo": "aaliyah-chang.png"},
-        "Yawar Ashraf":     {"status": "Graduate",      "role": "MASc Student",               "email": "TBD",              "hobbies": "TBD",                                  "photo": "yawar-ashraf.png"},
+        "Yawar Ashraf":     {"status": "Graduate",      "role": "MASc Student",               "email": "TBD",              "hobbies": "Squash, Reading",                      "photo": "yawar-ashraf.png"},
         "Zeph Van Iterson": {"status": "Undergraduate", "role": "Research Assistant (Mar 2024 - pres)", "email": "20zrvi@queensu.ca", "hobbies": "Cooking, Movies",          "photo": "zephvaniterson.jpg"},
         "Haoyu Li":         {"status": "Alumni",        "role": "MEng (Mar 2024 - Nov 2024)", "email": "17hl66@queensu.ca","hobbies": "",                                    "photo": "default.jpg"},
         "Elias Frigui":     {"status": "Alumni",        "role": "Research Assistant (Mar 2024 - Aug 2024)", "email": "21ef32@queensu.ca", "hobbies": "",                     "photo": "default.jpg"},


### PR DESCRIPTION
## Summary
- Set Yawar's hobbies on the members page
- Remove the stats bar from the publications page (and its related CSS)
- Minor tweak to `scripts/update_site.py`

## Changes
- `members.html` — Yawar's hobbies
- `publication.html` + `css/redesign.css` — remove publications stats bar and unused styles
- `scripts/update_site.py` — small adjustment